### PR TITLE
resolve problem in LaunchMuPDF()

### DIFF
--- a/bin/mupdf-launch.sh
+++ b/bin/mupdf-launch.sh
@@ -4,10 +4,10 @@ texfile="$2"
 mupdf "$1" &>/dev/null &
 mupid="$!"
 muwinid="0"
-nummps=$(xdotool search --pid $mupid --class MuPDF | wc -l 2>/dev/null)
+nummps=$(xdotool search --pid $mupid --class MuPDF | wc -l)
 until [ $nummps -gt 0 ] ; do
     sleep 0.1
-    nummps=$(xdotool search --pid $mupid --class MuPDF | wc -l 2>/dev/null)
+    nummps=$(xdotool search --pid $mupid --class MuPDF | wc -l)
 done
 echo -n "$(xdotool search --pid $mupid --class MuPDF | head -n1)" 
 # try to return focus to GVIM

--- a/ftplugin/tex/live-latex-preview.vim
+++ b/ftplugin/tex/live-latex-preview.vim
@@ -62,7 +62,7 @@ function! LaunchMuPDF()
             silent! call system("live-latex-update.sh \"" . b:Rootfile . "\" 999999 &>/dev/null")
         endif
         if filereadable(b:Pdfroot.".pdf")
-            let b:MuPDFWindowID = system("mupdf-launch.sh \"" . b:Pdfroot . ".pdf\" \"" . expand("%") . "\"")
+            let b:MuPDFWindowID = system("mupdf-launch.sh \"" . b:Pdfroot . ".pdf\" \"" . expand("%") . "\" 2> /dev/null")
             let b:Pdfviewing = "yes"
             echo "PDF preview now on." 
         else 


### PR DESCRIPTION
because vim's system() function returns not only stdout, but also stderr it is unreasonable only to redirect the stderr of 'wc' in 'mupdf-launch.sh' to '/dev/null'. It makes more sense to delete this redirection in 'mupdf-launch.sh' which makes debugging in those rare cases easier, in which wc writes to stderr. Instead i appended '2> /dev/null' in the corresponding system() call in LaunchMuPDF().

Maybe one may wonder of this commit, but without it, the script failed regularly on my machine.

In those cases, the variable "b:MuPDFWindowID" contained something like this:

X Error of failed request:  BadWindow (invalid Window parameter)
  Major opcode of failed request:  15 (X_QueryTree)
  Resource id in failed request:  0x10cb8c9
  Serial number of failed request:  2050
  Current serial number in output stream:  2050
79691915

Most likely very annoying for those who wants to replace something so flawless like gummi with vim.
